### PR TITLE
Environment variables

### DIFF
--- a/packages/cli/libs/commands/run/complete.command.spec.ts
+++ b/packages/cli/libs/commands/run/complete.command.spec.ts
@@ -32,6 +32,7 @@ jest.mock("@jyfti/engine", () => {
     transitionFrom: jest.fn(() => (stepResult$) =>
       stepResult$.pipe(require("rxjs/operators").map(() => ({})))
     ),
+    getOutput: () => ({}),
     resolveStep: () => ({}),
   };
   return {
@@ -83,6 +84,6 @@ describe("the complete command", () => {
     await complete("my-workflow");
     expect(logSpy).toHaveBeenNthCalledWith(1, printStepResult(stepResult));
     expect(errorSpy).toHaveBeenCalledTimes(0);
-    expect(writeStateSpy).toHaveBeenCalledTimes(0);
+    expect(writeStateSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cli/libs/commands/run/execute.command.ts
+++ b/packages/cli/libs/commands/run/execute.command.ts
@@ -5,6 +5,7 @@ import {
   State,
   Engine,
   isSuccess,
+  Environment,
 } from "@jyfti/engine";
 import { last, tap, catchError, mergeMap, takeWhile } from "rxjs/operators";
 import { from, OperatorFunction, of } from "rxjs";
@@ -29,16 +30,12 @@ import {
   validateEnvironmentOrTerminate,
 } from "../../validator";
 import logSymbols from "log-symbols";
-import { Assignment } from "../../types/assignment.type";
-import {
-  extractEnvironments,
-  mergeEnvironments,
-} from "../../data-access/environment.util";
+import { mergeEnvironments } from "../../data-access/environment.util";
 
 export async function execute(
   name?: string,
   inputList?: string[],
-  cmd?: { environment?: string; verbose?: boolean; envVar?: Assignment[] }
+  cmd?: { environment?: string; verbose?: boolean; envVar?: Environment }
 ): Promise<void> {
   const config = await readConfig();
   if (!name) {
@@ -52,7 +49,7 @@ export async function execute(
     name = isUrl(name) ? extractWorkflowName(name) : name;
     const environment = mergeEnvironments([
       await readEnvironmentOrTerminate(config, cmd?.environment),
-      ...extractEnvironments(cmd?.envVar || []),
+      cmd?.envVar || {},
     ]);
     validateEnvironmentOrTerminate(workflow, environment);
     if ((inputList || []).length === 0) {

--- a/packages/cli/libs/commands/run/execute.command.ts
+++ b/packages/cli/libs/commands/run/execute.command.ts
@@ -4,18 +4,10 @@ import {
   StepResult,
   State,
   Engine,
-  isFailure,
   isSuccess,
 } from "@jyfti/engine";
-import {
-  last,
-  tap,
-  catchError,
-  mergeMap,
-  takeUntil,
-  takeWhile,
-} from "rxjs/operators";
-import { from, OperatorFunction, empty, throwError, of } from "rxjs";
+import { last, tap, catchError, mergeMap, takeWhile } from "rxjs/operators";
+import { from, OperatorFunction, of } from "rxjs";
 import { promptWorkflow, promptWorkflowInputs } from "../../inquirer.service";
 import { printStepResult, printJson, printOutput } from "../../print.service";
 import {

--- a/packages/cli/libs/commands/run/step.command.ts
+++ b/packages/cli/libs/commands/run/step.command.ts
@@ -5,6 +5,7 @@ import {
   State,
   Engine,
   isFailure,
+  Environment,
 } from "@jyfti/engine";
 import { mergeMap, tap, catchError } from "rxjs/operators";
 import { from, OperatorFunction, empty, throwError, of } from "rxjs";
@@ -18,10 +19,11 @@ import { printStepResult } from "../../print.service";
 import { readEnvironmentOrTerminate } from "../../data-access/environment.dao";
 import { validateEnvironmentOrTerminate } from "../../validator";
 import { Config } from "../../types/config";
+import { mergeEnvironments } from "../../data-access/environment.util";
 
 export async function step(
   name?: string,
-  cmd?: { environment?: string; verbose?: boolean }
+  cmd?: { environment?: string; envVar?: Environment; verbose?: boolean }
 ): Promise<void> {
   const config = await readConfig();
   if (!name) {
@@ -34,10 +36,10 @@ export async function step(
   if (name) {
     const workflow = await readWorkflowOrTerminate(config, name);
     const state = await readStateOrTerminate(config, name);
-    const environment = await readEnvironmentOrTerminate(
-      config,
-      cmd?.environment
-    );
+    const environment = mergeEnvironments([
+      await readEnvironmentOrTerminate(config, cmd?.environment),
+      cmd?.envVar || {},
+    ]);
     validateEnvironmentOrTerminate(workflow, environment);
     const engine = createEngine(workflow, environment);
     if (engine.isComplete(state)) {

--- a/packages/cli/libs/data-access/environment.util.spec.ts
+++ b/packages/cli/libs/data-access/environment.util.spec.ts
@@ -1,30 +1,49 @@
-import { extractEnvironments, mergeEnvironments } from "./environment.util";
+import { extractEnvironment, mergeEnvironments } from "./environment.util";
 
 describe("environment utility functions", () => {
-  it("extract environments from assignments", () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV };
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  it("parses a flat assigment into an environment", () => {
+    process.env.ENV_VAR = "envVarValue";
+    const module = require("./environment.util");
+    expect(module.parseAssignment("envVar=ENV_VAR", {})).toEqual({
+      envVar: "envVarValue",
+    });
+  });
+
+  it("parses a nested assigment into an environment", () => {
+    process.env.GITHUB_TOKEN = "tokenValue";
+    const module = require("./environment.util");
     expect(
-      extractEnvironments([
-        {
-          accessor: ["token"],
-          value: "abc",
-        },
-        {
-          accessor: ["github", "auth", "token"],
-          value: "def",
-        },
-      ])
-    ).toEqual([
-      {
-        token: "abc",
-      },
-      {
-        github: {
-          auth: {
-            token: "def",
-          },
+      module.parseAssignment("github.auth.token=GITHUB_TOKEN", {})
+    ).toEqual({
+      github: { auth: { token: "tokenValue" } },
+    });
+  });
+
+  it("extracts a flat environment from an assignment", () => {
+    expect(extractEnvironment(["token"], "abc")).toEqual({
+      token: "abc",
+    });
+  });
+
+  it("extracts a nested environment from an assignment", () => {
+    expect(extractEnvironment(["github", "auth", "token"], "def")).toEqual({
+      github: {
+        auth: {
+          token: "def",
         },
       },
-    ]);
+    });
   });
 
   // TODO Nested environments should not be overridden, but the merging should recursively continue

--- a/packages/cli/libs/data-access/environment.util.spec.ts
+++ b/packages/cli/libs/data-access/environment.util.spec.ts
@@ -46,7 +46,6 @@ describe("environment utility functions", () => {
     });
   });
 
-  // TODO Nested environments should not be overridden, but the merging should recursively continue
   it("merges environments and prefers later environments", () => {
     expect(
       mergeEnvironments([
@@ -55,5 +54,11 @@ describe("environment utility functions", () => {
         { a: "a3" },
       ])
     ).toEqual({ a: "a3", b: "b2", c: "c1" });
+  });
+
+  it("merges nested environments without overriding", () => {
+    expect(
+      mergeEnvironments([{ a: { b: "b1", c: "c1" } }, { a: { b: "b2" } }])
+    ).toEqual({ a: { b: "b2", c: "c1" } });
   });
 });

--- a/packages/cli/libs/data-access/environment.util.spec.ts
+++ b/packages/cli/libs/data-access/environment.util.spec.ts
@@ -1,0 +1,40 @@
+import { extractEnvironments, mergeEnvironments } from "./environment.util";
+
+describe("environment utility functions", () => {
+  it("extract environments from assignments", () => {
+    expect(
+      extractEnvironments([
+        {
+          accessor: ["token"],
+          value: "abc",
+        },
+        {
+          accessor: ["github", "auth", "token"],
+          value: "def",
+        },
+      ])
+    ).toEqual([
+      {
+        token: "abc",
+      },
+      {
+        github: {
+          auth: {
+            token: "def",
+          },
+        },
+      },
+    ]);
+  });
+
+  // TODO Nested environments should not be overridden, but the merging should recursively continue
+  it("merges environments and prefers later environments", () => {
+    expect(
+      mergeEnvironments([
+        { a: "a1", b: "b1", c: "c1" },
+        { a: "a2", b: "b2" },
+        { a: "a3" },
+      ])
+    ).toEqual({ a: "a3", b: "b2", c: "c1" });
+  });
+});

--- a/packages/cli/libs/data-access/environment.util.ts
+++ b/packages/cli/libs/data-access/environment.util.ts
@@ -1,4 +1,5 @@
 import { Environment } from "@jyfti/engine";
+import { merge } from "lodash/fp";
 
 export function parseAssignment(
   assignmentStr: string,
@@ -16,10 +17,7 @@ export function parseAssignment(
 }
 
 export function mergeEnvironments(environments: Environment[]): Environment {
-  return environments.reduce(
-    (acc, environment) => ({ ...acc, ...environment }),
-    {}
-  );
+  return environments.reduce((acc, environment) => merge(acc, environment), {});
 }
 
 export function extractEnvironment(

--- a/packages/cli/libs/data-access/environment.util.ts
+++ b/packages/cli/libs/data-access/environment.util.ts
@@ -1,5 +1,19 @@
 import { Environment } from "@jyfti/engine";
-import { Assignment } from "../types/assignment.type";
+
+export function parseAssignment(
+  assignmentStr: string,
+  previous: Environment
+): Environment {
+  const [accessorString, environmentVariable] = assignmentStr.split("=", 2);
+  const accessor = accessorString.split(".");
+  const value = process.env[environmentVariable];
+  if (!value) {
+    throw new Error(
+      `The environment variable ${environmentVariable} is not set`
+    );
+  }
+  return mergeEnvironments([previous, extractEnvironment(accessor, value)]);
+}
 
 export function mergeEnvironments(environments: Environment[]): Environment {
   return environments.reduce(
@@ -8,16 +22,15 @@ export function mergeEnvironments(environments: Environment[]): Environment {
   );
 }
 
-export function extractEnvironments(assignments: Assignment[]): Environment[] {
-  return assignments.map(extractEnvironment);
-}
-
-function extractEnvironment(assignment: Assignment): Environment {
-  const rightmostAccessorIndex = assignment.accessor.length - 1;
+export function extractEnvironment(
+  accessor: string[],
+  value: string
+): Environment {
+  const rightmostAccessorIndex = accessor.length - 1;
   const rightmostObj: Environment = {
-    [assignment.accessor[rightmostAccessorIndex]]: assignment.value,
+    [accessor[rightmostAccessorIndex]]: value,
   };
-  return assignment.accessor
+  return accessor
     .slice(0, rightmostAccessorIndex)
     .reduceRight((acc, part) => ({ [part]: acc }), rightmostObj);
 }

--- a/packages/cli/libs/data-access/environment.util.ts
+++ b/packages/cli/libs/data-access/environment.util.ts
@@ -1,0 +1,23 @@
+import { Environment } from "@jyfti/engine";
+import { Assignment } from "../types/assignment.type";
+
+export function mergeEnvironments(environments: Environment[]): Environment {
+  return environments.reduce(
+    (acc, environment) => ({ ...acc, ...environment }),
+    {}
+  );
+}
+
+export function extractEnvironments(assignments: Assignment[]): Environment[] {
+  return assignments.map(extractEnvironment);
+}
+
+function extractEnvironment(assignment: Assignment): Environment {
+  const rightmostAccessorIndex = assignment.accessor.length - 1;
+  const rightmostObj: Environment = {
+    [assignment.accessor[rightmostAccessorIndex]]: assignment.value,
+  };
+  return assignment.accessor
+    .slice(0, rightmostAccessorIndex)
+    .reduceRight((acc, part) => ({ [part]: acc }), rightmostObj);
+}

--- a/packages/cli/libs/run.ts
+++ b/packages/cli/libs/run.ts
@@ -22,6 +22,12 @@ export function addRunSubCommands(command: commander.Command): void {
       "the name of the environment",
       "default"
     )
+    .option(
+      "--env-var [assignment]",
+      "an assignment to an individual variable of the expected environment",
+      parseAssignment,
+      {}
+    )
     .action(create);
 
   command
@@ -51,6 +57,12 @@ export function addRunSubCommands(command: commander.Command): void {
       "the name of the environment",
       "default"
     )
+    .option(
+      "--env-var [assignment]",
+      "an assignment to an individual variable of the expected environment",
+      parseAssignment,
+      {}
+    )
     .action(step);
 
   command
@@ -61,6 +73,12 @@ export function addRunSubCommands(command: commander.Command): void {
       "-e --environment <environment>",
       "the name of the environment",
       "default"
+    )
+    .option(
+      "--env-var [assignment]",
+      "an assignment to an individual variable of the expected environment",
+      parseAssignment,
+      {}
     )
     .action(complete);
 

--- a/packages/cli/libs/run.ts
+++ b/packages/cli/libs/run.ts
@@ -9,6 +9,7 @@ import {
   reset,
   create,
 } from "./commands";
+import { Assignment } from "./types/assignment.type";
 
 export function addRunSubCommands(command: commander.Command): void {
   command
@@ -23,15 +24,36 @@ export function addRunSubCommands(command: commander.Command): void {
     )
     .action(create);
 
+  function parseAssignment(
+    assignmentStr: string,
+    previous: Assignment[]
+  ): Assignment[] {
+    const [accessorString, environmentVariable] = assignmentStr.split("=", 2);
+    const accessor = accessorString.split(".");
+    const value = process.env[environmentVariable];
+    if (!value) {
+      throw new Error(
+        `The environment variable ${environmentVariable} is not set`
+      );
+    }
+    return [...previous, { accessor, value }];
+  }
+
   command
     .command("execute [name] [inputs...]", { isDefault: true })
     .description("execute a run of this workflow")
     .option("-v --verbose", "print step results")
     .option("-y --yes", "automatically answer confirmation questions with yes")
     .option(
-      "-e --environment <environment>",
+      "--environment <environment>",
       "the name of the environment",
       "default"
+    )
+    .option(
+      "-e --env-var [assignment]",
+      "an assignment to an individual variable of the expected environment",
+      parseAssignment,
+      []
     )
     .action(execute);
 

--- a/packages/cli/libs/run.ts
+++ b/packages/cli/libs/run.ts
@@ -30,12 +30,12 @@ export function addRunSubCommands(command: commander.Command): void {
     .option("-v --verbose", "print step results")
     .option("-y --yes", "automatically answer confirmation questions with yes")
     .option(
-      "--environment <environment>",
+      "-e --environment <environment>",
       "the name of the environment",
       "default"
     )
     .option(
-      "-e --env-var [assignment]",
+      "--env-var [assignment]",
       "an assignment to an individual variable of the expected environment",
       parseAssignment,
       {}

--- a/packages/cli/libs/run.ts
+++ b/packages/cli/libs/run.ts
@@ -9,7 +9,7 @@ import {
   reset,
   create,
 } from "./commands";
-import { Assignment } from "./types/assignment.type";
+import { parseAssignment } from "./data-access/environment.util";
 
 export function addRunSubCommands(command: commander.Command): void {
   command
@@ -23,21 +23,6 @@ export function addRunSubCommands(command: commander.Command): void {
       "default"
     )
     .action(create);
-
-  function parseAssignment(
-    assignmentStr: string,
-    previous: Assignment[]
-  ): Assignment[] {
-    const [accessorString, environmentVariable] = assignmentStr.split("=", 2);
-    const accessor = accessorString.split(".");
-    const value = process.env[environmentVariable];
-    if (!value) {
-      throw new Error(
-        `The environment variable ${environmentVariable} is not set`
-      );
-    }
-    return [...previous, { accessor, value }];
-  }
 
   command
     .command("execute [name] [inputs...]", { isDefault: true })
@@ -53,7 +38,7 @@ export function addRunSubCommands(command: commander.Command): void {
       "-e --env-var [assignment]",
       "an assignment to an individual variable of the expected environment",
       parseAssignment,
-      []
+      {}
     )
     .action(execute);
 

--- a/packages/cli/libs/types/assignment.type.ts
+++ b/packages/cli/libs/types/assignment.type.ts
@@ -1,0 +1,4 @@
+export interface Assignment {
+  accessor: string[];
+  value: string;
+}

--- a/packages/cli/libs/types/assignment.type.ts
+++ b/packages/cli/libs/types/assignment.type.ts
@@ -1,4 +1,0 @@
-export interface Assignment {
-  accessor: string[];
-  value: string;
-}

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1999,9 +1999,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.160",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.160.tgz",
-      "integrity": "sha512-aP03BShJoO+WVndoVj/WNcB/YBPt+CIU1mvaao2GRAHy2yg4pT/XS4XnVHEQBjPJGycWf/9seKEO9vopTJGkvA==",
+      "version": "4.14.166",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.166.tgz",
+      "integrity": "sha512-A3YT/c1oTlyvvW/GQqG86EyqWNrT/tisOIh2mW3YCgcx71TNjiTZA3zYZWA5BCmtsOTXjhliy4c4yEkErw6njA==",
       "dev": true
     },
     "@types/mock-fs": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,7 +49,7 @@
     "@types/bent": "^7.3.0",
     "@types/inquirer": "^7.3.0",
     "@types/jest": "^26.0.9",
-    "@types/lodash": "^4.14.159",
+    "@types/lodash": "^4.14.166",
     "@types/mock-fs": "^4.10.0",
     "@types/node": "^14.0.27",
     "@types/rx": "^4.1.2",

--- a/packages/engine/.gitignore
+++ b/packages/engine/.gitignore
@@ -4,3 +4,4 @@ jyfti.state.json
 out
 environments
 coverage
+docs

--- a/packages/engine/libs/services/step-execution.ts
+++ b/packages/engine/libs/services/step-execution.ts
@@ -1,5 +1,5 @@
 import { Observable, of, throwError } from "rxjs";
-import { catchError, mergeMap, map } from "rxjs/operators";
+import { mergeMap, map } from "rxjs/operators";
 
 import { evaluate } from "./evaluation";
 import {

--- a/packages/engine/package-lock.json
+++ b/packages/engine/package-lock.json
@@ -2462,6 +2462,12 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true
+    },
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
@@ -3953,6 +3959,18 @@
         "map-cache": "^0.2.2"
       }
     },
+    "fs-extra": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+      "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+      "dev": true,
+      "requires": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^1.0.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -4096,6 +4114,27 @@
       "dev": true,
       "optional": true
     },
+    "handlebars": {
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
+      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -4189,6 +4228,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
       "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
+      "dev": true
+    },
+    "highlight.js": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.5.0.tgz",
+      "integrity": "sha512-xTmvd9HiIHR6L53TMC7TKolEj65zG1XU+Onr8oi86mYa+nLcIbxTTWkpW7CsEwv/vK7u1zb8alZIMLDqqN6KTw==",
       "dev": true
     },
     "hosted-git-info": {
@@ -4316,6 +4361,12 @@
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
       "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
+      "dev": true
+    },
+    "interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
       "dev": true
     },
     "invariant": {
@@ -6568,6 +6619,24 @@
         "minimist": "^1.2.5"
       }
     },
+    "jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      },
+      "dependencies": {
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+          "dev": true
+        }
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -6686,6 +6755,12 @@
         "yallist": "^4.0.0"
       }
     },
+    "lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -6732,6 +6807,12 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
+    },
+    "marked": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.7.tgz",
+      "integrity": "sha512-No11hFYcXr/zkBvL6qFmAp1z6BKY3zqLMHny/JN/ey+al7qwCM2+CMBL9BOgqMxZU36fz4cCWfn2poWIf7QRXA==",
+      "dev": true
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -6850,6 +6931,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
     "nice-try": {
@@ -7411,6 +7498,15 @@
         "picomatch": "^2.2.1"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "regenerate": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.1.tgz",
@@ -7925,6 +8021,17 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
+    },
+    "shelljs": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
     },
     "shellwords": {
       "version": "0.1.1",
@@ -8626,11 +8733,54 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typedoc": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.19.2.tgz",
+      "integrity": "sha512-oDEg1BLEzi1qvgdQXc658EYgJ5qJLVSeZ0hQ57Eq4JXy6Vj2VX4RVo18qYxRWz75ifAaYuYNBUCnbhjd37TfOg==",
+      "dev": true,
+      "requires": {
+        "fs-extra": "^9.0.1",
+        "handlebars": "^4.7.6",
+        "highlight.js": "^10.2.0",
+        "lodash": "^4.17.20",
+        "lunr": "^2.3.9",
+        "marked": "^1.1.1",
+        "minimatch": "^3.0.0",
+        "progress": "^2.0.3",
+        "semver": "^7.3.2",
+        "shelljs": "^0.8.4",
+        "typedoc-default-themes": "^0.11.4"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
+    "typedoc-default-themes": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.11.4.tgz",
+      "integrity": "sha512-Y4Lf+qIb9NTydrexlazAM46SSLrmrQRqWiD52593g53SsmUFioAsMWt8m834J6qsp+7wHRjxCXSZeiiW5cMUdw==",
+      "dev": true
+    },
     "typescript": {
       "version": "3.9.7",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
       "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
       "dev": true
+    },
+    "uglify-js": {
+      "version": "3.12.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.3.tgz",
+      "integrity": "sha512-feZzR+kIcSVuLi3s/0x0b2Tx4Iokwqt+8PJM7yRHKuldg4MLdam4TCFeICv+lgDtuYiCtdmrtIP+uN9LWvDasw==",
+      "dev": true,
+      "optional": true
     },
     "undefsafe": {
       "version": "2.0.3",
@@ -8706,6 +8856,12 @@
       "requires": {
         "crypto-random-string": "^2.0.0"
       }
+    },
+    "universalify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+      "dev": true
     },
     "unset-value": {
       "version": "1.0.0",
@@ -8949,6 +9105,12 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "wrap-ansi": {

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -56,6 +56,7 @@
     "prettier": "2.1.1",
     "ts-node": "^8.10.2",
     "tsconfig-paths": "^3.9.0",
+    "typedoc": "^0.19.2",
     "typescript": "^3.9.7"
   },
   "dependencies": {

--- a/packages/engine/typedoc.json
+++ b/packages/engine/typedoc.json
@@ -1,0 +1,10 @@
+{
+  "inputFiles": [
+    "./libs/services/engine.ts",
+    "./libs/services/validator.ts",
+    "./libs/types"
+  ],
+  "exclude": "**/*+(index.ts|.spec.ts|__mocks__)",
+  "mode": "modules",
+  "out": "docs"
+}


### PR DESCRIPTION
Allows all env variables expected in a workflow to be alternatively passed via environment variable instead of via file. This is helpful for CI environments like GitHub Actions where it is easier to pass environment variables than to create files.

A variable from environment needs to be explicitly specified via something like `--env-var github.auth.token=GITHUB_TOKEN`. This causes Jyfti to read an environment variable `GITHUB_TOKEN` and merge it into a given environment.